### PR TITLE
Fix AboutView recursive import bug

### DIFF
--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -1,10 +1,11 @@
 <template>
   <main>
-    <AboutView />
+    <About />
   </main>
 </template>
 
 <script setup lang="ts">
+import About from '../components/About.vue'
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- fix infinite recursion in `AboutView.vue` by importing `About` component

## Testing
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402b79b9a4832e9499bf4936ae8100