### PR TITLE
Improve site styling

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,21 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #333;
+  background: linear-gradient(135deg, #f9fafb, #e0f2ff);
+  min-height: 100vh;
+}
+
+nav a {
+  color: #2196f3;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+h1, h2, h3 {
+  margin-top: 0;
+  font-weight: 600;
+}

--- a/src/assets/timeline.css
+++ b/src/assets/timeline.css
@@ -18,7 +18,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background-color: #2196F3;
+  background: linear-gradient(to right, #42a5f5, #7e57c2);
 }
 
 .timeline-item-wrapper {
@@ -35,13 +35,13 @@
   transform: translate(-50%, -50%);
   width: 20px;
   height: 20px;
-  background-color: #2196F3;
+  background: linear-gradient(135deg, #42a5f5, #7e57c2);
   border-radius: 50%;
   cursor: pointer;
 }
 
 .timeline-dot:hover {
-  background-color: #ff5722;
+  background: linear-gradient(135deg, #ab47bc, #42a5f5);
 }
 
 .timeline-item {

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -8,3 +8,12 @@
     <p>Praesent sit amet eros vitae turpis ullamcorper semper ut et tortor.</p>
   </div>
 </template>
+
+<style scoped>
+.about {
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+  text-align: left;
+}
+</style>

--- a/src/components/ContactItem.vue
+++ b/src/components/ContactItem.vue
@@ -16,3 +16,14 @@ export default {
     }
 }
 </script>
+
+<style scoped>
+.contact-item {
+  background: #fff;
+  border-radius: 6px;
+  padding: 10px 15px;
+  margin-bottom: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  text-align: left;
+}
+</style>

--- a/src/components/Contacts.vue
+++ b/src/components/Contacts.vue
@@ -18,3 +18,11 @@ import ContactBlock from './ContactItem.vue'
 const store = useContactsStore()
 const { contacts: contactItems } = storeToRefs(store)
 </script>
+
+<style scoped>
+.contacts {
+  max-width: 700px;
+  margin: 0 auto;
+  text-align: left;
+}
+</style>

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -32,11 +32,11 @@ export default {
   right: 0;
   bottom: 0;
   /*
-   * Add your own background image by replacing the color below with
+   * Add your own background image by replacing the gradient below with
    * `background-image: url('@/image.png');` and placing a file at
    * `src/image.png`.
    */
-  background-color: #333;
+  background: linear-gradient(120deg, #84fab0 0%, #8fd3f4 100%);
   background-size: cover;
   background-position: center;
   background-attachment: fixed;
@@ -46,9 +46,10 @@ export default {
 
 .hero-overlay {
   text-align: center;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
   padding: 20px;
   border-radius: 8px;
+  backdrop-filter: blur(2px);
 }
 
 .hero-title {


### PR DESCRIPTION
## Summary
- add base page styling and typography
- enhance hero background and overlay
- refine timeline colors
- style about and contacts pages

## Testing
- `npm run type-check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688203d3a908832e80d2d477f25c674a